### PR TITLE
Conditional passing grade display 

### DIFF
--- a/src/containers/CourseCard/components/CourseCardBanners/CertificateBanner.jsx
+++ b/src/containers/CourseCard/components/CourseCardBanners/CertificateBanner.jsx
@@ -56,7 +56,7 @@ export const CertificateBanner = ({ cardId }) => {
     if (isAudit) {
       return (
         <Banner>
-          {formatMessage(messages.passingGrade, { minPassingGrade })}
+        {minPassingGrade > 1 ? formatMessage(messages.passingGrade, { minPassingGrade }) : null}
         </Banner>
       );
     }
@@ -71,7 +71,7 @@ export const CertificateBanner = ({ cardId }) => {
     }
     return (
       <Banner variant="warning">
-        {formatMessage(messages.certMinGrade, { minPassingGrade })}
+      {minPassingGrade > 1 ? formatMessage(messages.certMinGrade, { minPassingGrade }) : null}
       </Banner>
     );
   }


### PR DESCRIPTION
- Updated the CertificateBanner component to only display the passing grade message if minPassingGrade is greater than 1%.
- Added conditional logic in both the "Audit" and "Non-Passing" sections to ensure that the passing grade message does not appear when minPassingGrade is 1% or lower.
- Maintained the rest of the banner rendering logic based on the learner's course status (e.g., audit, archived, or not passing).